### PR TITLE
add support for encoding first/last doc per term

### DIFF
--- a/lucene/core/src/java/org/apache/lucene/codecs/BlockTermState.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/BlockTermState.java
@@ -31,6 +31,9 @@ public class BlockTermState extends OrdTermState {
   /** total number of occurrences of this term */
   public long totalTermFreq;
 
+  public int firstDoc = -1;
+  public int lastDoc = -1;
+
   /** the term's ord in the current block */
   public int termBlockOrd;
   /** fp into the terms dict primary file (_X.tim) that holds this term */

--- a/lucene/core/src/java/org/apache/lucene/codecs/PushPostingsWriterBase.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/PushPostingsWriterBase.java
@@ -78,6 +78,8 @@ public abstract class PushPostingsWriterBase extends PostingsWriterBase {
    */
   public abstract void finishTerm(BlockTermState state) throws IOException;
 
+  public static final String INTERVAL_WANTED = "__INTERVAL_WANTED__";
+
   /**
    * Sets the current field for writing, and returns the fixed length of long[] metadata (which is
    * fixed per field), called when the writing switches to another field.
@@ -128,11 +130,17 @@ public abstract class PushPostingsWriterBase extends PostingsWriterBase {
 
     int docFreq = 0;
     long totalTermFreq = 0;
+    int firstDoc = -1;
+    int lastDoc = -1;
     while (true) {
       int docID = postingsEnum.nextDoc();
       if (docID == PostingsEnum.NO_MORE_DOCS) {
         break;
       }
+      if (firstDoc < 0) {
+        firstDoc = docID;
+      }
+      lastDoc = docID;
       docFreq++;
       docsSeen.set(docID);
       int freq;
@@ -169,6 +177,8 @@ public abstract class PushPostingsWriterBase extends PostingsWriterBase {
     } else {
       BlockTermState state = newTermState();
       state.docFreq = docFreq;
+      state.firstDoc = firstDoc;
+      state.lastDoc = lastDoc;
       state.totalTermFreq = writeFreqs ? totalTermFreq : -1;
       finishTerm(state);
       return state;

--- a/lucene/core/src/java/org/apache/lucene/codecs/blocktree/SegmentTermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/blocktree/SegmentTermsEnum.java
@@ -1116,6 +1116,24 @@ final class SegmentTermsEnum extends BaseTermsEnum {
   }
 
   @Override
+  public int firstDoc() throws IOException {
+    assert !eof;
+    // if (DEBUG) System.out.println("BTR.firstDoc");
+    currentFrame.decodeMetaData();
+    // if (DEBUG) System.out.println("  return " + currentFrame.state.firstDoc);
+    return currentFrame.state.firstDoc;
+  }
+
+  @Override
+  public int lastDoc() throws IOException {
+    assert !eof;
+    // if (DEBUG) System.out.println("BTR.lastDoc");
+    currentFrame.decodeMetaData();
+    // if (DEBUG) System.out.println("  return " + currentFrame.state.lastDoc);
+    return currentFrame.state.lastDoc;
+  }
+
+  @Override
   public long totalTermFreq() throws IOException {
     assert !eof;
     currentFrame.decodeMetaData();

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene84/Lucene84PostingsReader.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene84/Lucene84PostingsReader.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import org.apache.lucene.codecs.BlockTermState;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.codecs.PostingsReaderBase;
+import org.apache.lucene.codecs.PushPostingsWriterBase;
 import org.apache.lucene.codecs.lucene84.Lucene84PostingsFormat.IntBlockTermState;
 import org.apache.lucene.index.FieldInfo;
 import org.apache.lucene.index.Impacts;
@@ -210,14 +211,21 @@ public final class Lucene84PostingsReader extends PostingsReaderBase {
       termState.payStartFP = 0;
     }
 
+    boolean storeIntervals = Boolean.parseBoolean(fieldInfo.getAttribute(PushPostingsWriterBase.INTERVAL_WANTED));
     if (version >= VERSION_COMPRESSED_TERMS_DICT_IDS) {
       final long l = in.readVLong();
       if ((l & 0x01) == 0) {
         termState.docStartFP += l >>> 1;
         if (termState.docFreq == 1) {
           termState.singletonDocID = in.readVInt();
+          termState.firstDoc = termState.singletonDocID;
+          termState.lastDoc = termState.singletonDocID;
         } else {
           termState.singletonDocID = -1;
+          if (storeIntervals) {
+            termState.firstDoc = in.readVInt();
+            termState.lastDoc = in.readVInt();
+          }
         }
       } else {
         assert absolute == false;
@@ -237,6 +245,8 @@ public final class Lucene84PostingsReader extends PostingsReaderBase {
     if (version < VERSION_COMPRESSED_TERMS_DICT_IDS) {
       if (termState.docFreq == 1) {
         termState.singletonDocID = in.readVInt();
+        termState.firstDoc = termState.singletonDocID;
+        termState.lastDoc = termState.singletonDocID;
       } else {
         termState.singletonDocID = -1;
       }

--- a/lucene/core/src/java/org/apache/lucene/codecs/lucene84/Lucene84PostingsWriter.java
+++ b/lucene/core/src/java/org/apache/lucene/codecs/lucene84/Lucene84PostingsWriter.java
@@ -481,6 +481,7 @@ public final class Lucene84PostingsWriter extends PushPostingsWriterBase {
   public void encodeTerm(
       DataOutput out, FieldInfo fieldInfo, BlockTermState _state, boolean absolute)
       throws IOException {
+    boolean storeIntervals = Boolean.parseBoolean(fieldInfo.getAttribute(INTERVAL_WANTED));
     IntBlockTermState state = (IntBlockTermState) _state;
     if (absolute) {
       lastState = emptyState;
@@ -501,6 +502,13 @@ public final class Lucene84PostingsWriter extends PushPostingsWriterBase {
       out.writeVLong((state.docStartFP - lastState.docStartFP) << 1);
       if (state.singletonDocID != -1) {
         out.writeVInt(state.singletonDocID);
+        state.firstDoc = state.singletonDocID;
+        state.lastDoc = state.singletonDocID;
+      } else {
+        if (storeIntervals) {
+          out.writeVInt(state.firstDoc);
+          out.writeVInt(state.lastDoc);
+        }
       }
     }
 

--- a/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
+++ b/lucene/core/src/java/org/apache/lucene/index/TermsEnum.java
@@ -114,6 +114,22 @@ public abstract class TermsEnum implements BytesRefIterator {
   public abstract int docFreq() throws IOException;
 
   /**
+   * Returns the first docId of documents containing the current term. Do not call this when the enum is
+   * unpositioned. {@link SeekStatus#END}.
+   */
+  public int firstDoc() throws IOException {
+      return -1;
+  }
+
+  /**
+   * Returns the last docId of documents containing the current term. Do not call this when the enum is
+   * unpositioned. {@link SeekStatus#END}.
+   */
+  public int lastDoc() throws IOException {
+      return -1;
+  }
+
+  /**
    * Returns the total number of occurrences of this term across all documents (the sum of the
    * freq() for each doc that has this term). Note that, like other term measures, this measure does
    * not take deleted documents into account.


### PR DESCRIPTION
Add support for encoding first+last docid per term. This is useful in calculating an interval if docs are in time order.

To enable, add an attribute to the Field:
```
FieldType type = new FieldType();
type.putAttribute(PushPostingsWriterBase.INTERVAL_WANTED, "true");
Field f = new Field("foo", "bar", type);
```

To read the interval, use the accessor methods added to TermsEnum:
```
TermsEnum te = terms.iterator();
int firstDoc = te.firstDoc();
int lastDoc = te.lastDoc();
```

This does NOT introduce overhead in the case where a term has only 1 doc (Lucene has an optimization to use the docid in place for the pointer). In this case, first/last Docids will be set to the singleton docid.

This is backwards compatible, if the attribute is not set, behavior is the same as vanilla lucene.

Limitations:
* Only supported for newer indexing format, e.g. > Lucene 8.0, older versions first/last docids will be -1 indicating this is not supported.
